### PR TITLE
Improve efficiency of stochastic model.

### DIFF
--- a/covid_ode.py
+++ b/covid_ode.py
@@ -13,26 +13,26 @@ from covid.util import sanitise_parameter, sanitise_settings, seed_areas
 
 
 def sum_age_groups(sim):
-    infec = sim[:, 2, :]
+    infec = sim[:, :, 2]
     infec = infec.reshape([infec.shape[0], 152, 17])
     infec_uk = infec.sum(axis=2)
     return infec_uk
 
 
 def sum_la(sim):
-    infec = sim[:, 2, :]
+    infec = sim[:, :, 2]
     infec = infec.reshape([infec.shape[0], 152, 17])
     infec_uk = infec.sum(axis=1)
     return infec_uk
 
 
 def sum_total_removals(sim):
-    remove = sim[:, 3, :]
+    remove = sim[:, :, 3]
     return remove.sum(axis=1)
 
 
 def final_size(sim):
-    remove = sim[:, 3, :]
+    remove = sim[:, :, 3]
     remove = remove.reshape([remove.shape[0], 152, 17])
     fs = remove[-1, :, :].sum(axis=0)
     return fs
@@ -52,7 +52,7 @@ def write_hdf5(filename, param, t, sim):
 
 def plot_total_curve(sim):
     infec_uk = sum_la(sim)
-    infec_uk = infec_uk.sum(axis=1)
+    infec_uk = infec_uk.sum(axis=-1)
     removals = sum_total_removals(sim)
     times = np.datetime64('2020-02-20') + np.arange(removals.shape[0])
     plt.plot(times, infec_uk, 'r-', label='Infected')
@@ -66,7 +66,7 @@ def plot_total_curve(sim):
 
 def plot_infec_curve(ax, sim, label):
     infec_uk = sum_la(sim)
-    infec_uk = infec_uk.sum(axis=1)
+    infec_uk = infec_uk.sum(axis=-1)
     times = np.datetime64('2020-02-20') + np.arange(infec_uk.shape[0])
     ax.plot(times, infec_uk, '-', label=label)
 
@@ -75,7 +75,7 @@ def plot_by_age(sim, labels, t0=np.datetime64('2020-02-20'), ax=None):
     if ax is None:
         ax = plt.figure().gca()
     infec_uk = sum_la(sim)
-    total_uk = infec_uk.mean(axis=1)
+    total_uk = infec_uk.mean(axis=-1)
     t = t0 + np.arange(infec_uk.shape[0])
     colours = plt.cm.viridis(np.linspace(0., 1., infec_uk.shape[1]))
     for i in range(infec_uk.shape[1]):
@@ -88,7 +88,7 @@ def plot_by_la(sim, labels, t0=np.datetime64('2020-02-20'), ax=None):
     if ax is None:
         ax = plt.figure().gca()
     infec_uk = sum_age_groups(sim)
-    total_uk = infec_uk.mean(axis=1)
+    total_uk = infec_uk.mean(axis=-1)
     t = t0 + np.arange(infec_uk.shape[0])
     colours = plt.cm.viridis(np.linspace(0., 1., infec_uk.shape[1]))
     for i in range(infec_uk.shape[1]):


### PR DESCRIPTION
Big changes:
 1. replace python for loop with tf.while_loop
 2. work with a transposed state tensor shape
   - instead of [4, nlads * nages], use [nlads * nages, 4]
   - this made it pretty easy to eliminate some transposes in
     propagate_fn (there were comments there seemingly contemplating
     this shape arrangement)
   - this feels a little more natural to me, too; in TFP we'd call the 4
     SEIR states components of the "event shape" of the system, and the
     nlads * nages part a "batch shape" (although one could reasonably
     also combine these together into one big matrix "event shape")
   - anyway, this allowed elimination of 3 transpose ops which makes for
     simpler code and avoids some memcpys
   - I also made an effort to update surrounding code to use the same data
     layout, but it seems like mcmc.py and covid_ode.py are broken right
     now anyway, due to other changes made in support of stochastic mode,
     so I couldn't confirm that my changes were sufficient.
 3. switch off XLA (which didn't yield any clear improvement, although
    it also didn't really hurt), and disable autograph (which tries to
    do things like rewrite python for loops into TF graph code but tends
    to produce less performant than manually optimized code like what
    I've done here)